### PR TITLE
디자인 9차 수정

### DIFF
--- a/src/page/Mypage/components/NoticeItem.jsx
+++ b/src/page/Mypage/components/NoticeItem.jsx
@@ -87,7 +87,7 @@ const Text = styled.p`
   color: #000;
 `;
 function NoticeItem({ organization, min, text, isread, link }) {
-  const maxLength = 37; //37자까지 표시
+  const maxLength = 30; //30자까지 표시
   const slicedText =
     text.length > maxLength ? text.slice(0, maxLength) + "..." : text;
 


### PR DESCRIPTION
1. 메인알림 - 알림의 text가 30자로 표시되게 변경 (기존 37자)